### PR TITLE
Add edge weight

### DIFF
--- a/addon/components/visjs-edge.js
+++ b/addon/components/visjs-edge.js
@@ -24,6 +24,19 @@ export default VisJsChild.extend({
     return `${this.get('from')}-${this.get('to')}`;
   }),
 
+  /**
+   * @public
+   *
+   * If set this defines edge's weight (thickness).
+   * @type {Int}
+   */
+  value: undefined,
+
+  valueChanged: Ember.observer('value', function() {
+    let container = this.get('containerLayer');
+    container.updateEdgeValue(this.get('eId'), this.get('value'));
+  }),
+
   arrowChanged: Ember.observer('arrows', function() {
     let container = this.get('containerLayer');
     container.updateEdgeArrow(this.get('eId'), this.get('arrows'));

--- a/addon/components/visjs-network.js
+++ b/addon/components/visjs-network.js
@@ -186,6 +186,10 @@ export default Ember.Component.extend(ContainerMixin, {
       simplifiedEdge.arrows = edge.get('arrows');
     }
 
+    if (edge.get('value')) {
+      simplifiedEdge.value = edge.get('value');
+    }
+
     edges.add(simplifiedEdge);
   },
 


### PR DESCRIPTION
First of more additions to come, I added support for an edge's weight to be passed as param to the component:

```
{{#each model.edges as |edge|}}
  {{visjs-edge from=edge.from to=edge.to value=edge.value}}
{{/each}}
```
