### PR TITLE
Add support for more node/edge attributes, provide array of nodes and edges as component parameter

### DIFF
--- a/addon/components/visjs-edge.js
+++ b/addon/components/visjs-edge.js
@@ -24,6 +24,19 @@ export default VisJsChild.extend({
     return `${this.get('from')}-${this.get('to')}`;
   }),
 
+  /**
+   * @public
+   *
+   * If set this defines edge's weight (thickness).
+   * @type {Int}
+   */
+  value: undefined,
+
+  valueChanged: Ember.observer('value', function() {
+    let container = this.get('containerLayer');
+    container.updateEdgeValue(this.get('eId'), this.get('value'));
+  }),
+
   arrowChanged: Ember.observer('arrows', function() {
     let container = this.get('containerLayer');
     container.updateEdgeArrow(this.get('eId'), this.get('arrows'));

--- a/addon/components/visjs-edge.js
+++ b/addon/components/visjs-edge.js
@@ -24,6 +24,20 @@ export default VisJsChild.extend({
     return `${this.get('from')}-${this.get('to')}`;
   }),
 
+  /**
+   * @public
+   *
+   * If set this displays a value under/in the node, depending on
+   * whether an image is shown or not.
+   * @type {String}
+   */
+  value: undefined,
+
+  valueChanged: Ember.observer('value', function() {
+    let container = this.get('containerLayer');
+    container.updateEdgeValue(this.get('eId'), this.get('value'));
+  }),
+
   arrowChanged: Ember.observer('arrows', function() {
     let container = this.get('containerLayer');
     container.updateEdgeArrow(this.get('eId'), this.get('arrows'));

--- a/addon/components/visjs-edge.js
+++ b/addon/components/visjs-edge.js
@@ -37,6 +37,19 @@ export default VisJsChild.extend({
     container.updateEdgeValue(this.get('eId'), this.get('value'));
   }),
 
+  /**
+   * @public
+   *
+   * If set this defines edge's color
+   * @type {Int}
+   */
+  color: undefined,
+
+  colorChanged: Ember.observer('color', function() {
+    let container = this.get('containerLayer');
+    container.updateEdgeColor(this.get('eId'), this.get('color'));
+  }),
+
   arrowChanged: Ember.observer('arrows', function() {
     let container = this.get('containerLayer');
     container.updateEdgeArrow(this.get('eId'), this.get('arrows'));

--- a/addon/components/visjs-network.js
+++ b/addon/components/visjs-network.js
@@ -186,6 +186,10 @@ export default Ember.Component.extend(ContainerMixin, {
       simplifiedEdge.arrows = edge.get('arrows');
     }
 
+    if (edge.get('value')) {
+      simplifiedEdge.value = edge.get('value');
+    }
+
     edges.add(simplifiedEdge);
   },
 

--- a/addon/components/visjs-network.js
+++ b/addon/components/visjs-network.js
@@ -15,8 +15,17 @@ export default Ember.Component.extend(ContainerMixin, {
   init() {
     this._super(...arguments);
 
-    this.set('nodes', new vis.DataSet([]));
-    this.set('edges', new vis.DataSet([]));
+    if(this.get('nodesSet') || this.get('nodesSet').size === 0) {
+      this.set('nodes', new vis.DataSet([]));
+    } else {
+      this.set('nodes', new vis.DataSet(this.get('nodesSet')));
+    }
+
+    if(this.get('edgesSet') || this.get('edgesSet').size === 0) {
+      this.set('edges', new vis.DataSet([]));
+    } else {
+      this.set('edges', new vis.DataSet(this.get('edgesSet')));
+    }
   },
 
   didInsertElement() {
@@ -170,7 +179,7 @@ export default Ember.Component.extend(ContainerMixin, {
       simplifiedNode.y = node.get('posY');
     }
 
-    if (node.get('value')) {
+    if (node.get('value') || node.get('value') === 0) {
       simplifiedNode.value = node.get('value');
     }
 

--- a/addon/components/visjs-network.js
+++ b/addon/components/visjs-network.js
@@ -170,6 +170,10 @@ export default Ember.Component.extend(ContainerMixin, {
       simplifiedNode.y = node.get('posY');
     }
 
+    if (node.get('value')) {
+      simplifiedNode.value = node.get('value');
+    }
+
     if (node.get('image')) {
       simplifiedNode.shape = 'image';
       simplifiedNode.image = node.get('image');
@@ -188,6 +192,10 @@ export default Ember.Component.extend(ContainerMixin, {
 
     if (edge.get('value')) {
       simplifiedEdge.value = edge.get('value');
+    }
+
+    if (edge.get('color')) {
+      simplifiedEdge.color = edge.get('color');
     }
 
     edges.add(simplifiedEdge);

--- a/addon/components/visjs-network.js
+++ b/addon/components/visjs-network.js
@@ -15,17 +15,8 @@ export default Ember.Component.extend(ContainerMixin, {
   init() {
     this._super(...arguments);
 
-    if(this.get('nodesSet') || this.get('nodesSet').size === 0) {
-      this.set('nodes', new vis.DataSet([]));
-    } else {
-      this.set('nodes', new vis.DataSet(this.get('nodesSet')));
-    }
-
-    if(this.get('edgesSet') || this.get('edgesSet').size === 0) {
-      this.set('edges', new vis.DataSet([]));
-    } else {
-      this.set('edges', new vis.DataSet(this.get('edgesSet')));
-    }
+    this.set('nodes', new vis.DataSet([]));
+    this.set('edges', new vis.DataSet(this.get('edgesSet')));
   },
 
   didInsertElement() {
@@ -40,6 +31,13 @@ export default Ember.Component.extend(ContainerMixin, {
       { nodes: this.get('nodes'), edges: this.get('edges') },
       options
     );
+
+    if(this.get('nodesSet') && this.get('edgesSet')) {
+      network.setData({
+        nodes: this.get('nodesSet'),
+        edges: this.get('edgesSet')
+      });
+    }
 
     let _this = this;
 

--- a/addon/components/visjs-node.js
+++ b/addon/components/visjs-node.js
@@ -52,7 +52,7 @@ export default VisJsChild.extend({
   imageChanged: Ember.observer('image', function() {
     let container = this.get('containerLayer');
     container.updateNodeImage(this.get('nId'), this.get('image'));
-  })
+  }),
 
   /**
    * @public

--- a/addon/components/visjs-node.js
+++ b/addon/components/visjs-node.js
@@ -54,4 +54,17 @@ export default VisJsChild.extend({
     container.updateNodeImage(this.get('nId'), this.get('image'));
   })
 
+  /**
+   * @public
+   *
+   * If set, a value would be set to alter node's size
+   * @type {Number}
+   */
+  value: false,
+
+  valueChanged: Ember.observer('value', function() {
+    let container = this.get('containerLayer');
+    container.updateNodeValue(this.get('nId'), this.get('value'));
+  })
+
 });


### PR DESCRIPTION
Add support for:
- node size (value)
- edge thickness (value)
- edge color (color)

Now it's possible to provide an already build array of nodes AND an array of edges like this:

```
{{#visjs-network options=networkOptions nodesSet=model.graph.nodes edgesSet=model.graph.edges}}
{{/visjs-network}}
```

And also like this:

```
{{#visjs-network options=networkOptions}}
  {{#each model.graph.nodes as |node|}}
      {{visjs-node nId=node.id label=node.label value=node.value color='rgb(39,239,252)'}}
  {{/each}}
  {{#each model.graph.edges as |edge|}}
    {{visjs-edge from=edge.from to=edge.to value=edge.value color='rgb(49,57,57)'}}
  {{/each}}
{{/visjs-network}}
```

I haven't tested what happens if you provide both, probably some exception should be raised not allowing it, or maybe the component nodes/edges defined via hbs should be added to the provided arrays. To be determined :-)

Thanks for all the work on this, I'm going to remove my previously created PRs that are now a part of this bigger, improved one.
